### PR TITLE
Show rounds to play on scoreboard

### DIFF
--- a/games/little-vigilante/src/server/LittleVigilanteRoom.ts
+++ b/games/little-vigilante/src/server/LittleVigilanteRoom.ts
@@ -94,6 +94,7 @@ export class LittleVigilanteRoom extends Room<LittleVigilanteState> {
     // initialize empty room state
     const state = new LittleVigilanteState();
     state.currentRound = 1;
+    state.roundsToPlay = roundsToPlay;
     state.currentTick = 0;
     state.lastDownState = new MapSchema<number>();
     state.chat = new ChatState();

--- a/games/little-vigilante/src/server/little-vigilante-server.machine.ts
+++ b/games/little-vigilante/src/server/little-vigilante-server.machine.ts
@@ -34,6 +34,12 @@ export interface LittleVigilanteServerContext {
   room: Room<LittleVigilanteState>;
 }
 
+type LittleVigilanteRoomSettings = {
+  votingTimeSeconds: number;
+  discussionTimeSeconds: number;
+  roundsToPlay: number;
+};
+
 type Guard = (
   context: LittleVigilanteServerContext,
   event: LittleVigilanteServerEvent
@@ -114,11 +120,7 @@ const isDetectiveArrested: Guard = ({ room }) =>
 
 export const createLittleVigilanteServerMachine = (
   room: Room<LittleVigilanteState>,
-  settings: {
-    votingTimeSeconds: number;
-    discussionTimeSeconds: number;
-    roundsToPlay: number;
-  }
+  settings: LittleVigilanteRoomSettings
 ) => {
   // todo just use context for this
   const cacheMap = new Map();
@@ -714,7 +716,7 @@ export const createLittleVigilanteServerMachine = (
         anyPlayerIdle: ({ room }, event) =>
           selectIdlePlayers(getSnapshot(room.state)).length > 0,
         hasMoreRounds: ({ room }) =>
-          room.state.currentRound + 1 <= settings.roundsToPlay,
+          room.state.currentRound + 1 <= room.state.roundsToPlay,
         timesUp: ({ room }) => room.state.timeRemaining <= 0,
         allPlayersConnected: ({ room }, event) =>
           selectAllPlayersConnected(room.state),

--- a/games/little-vigilante/src/ui/organisms/scoreboard.component.tsx
+++ b/games/little-vigilante/src/ui/organisms/scoreboard.component.tsx
@@ -13,11 +13,16 @@ export const Scoreboard = () => {
   const currentRound = useLittleVigilanteSelector(
     (state) => state.currentRound
   );
+  const roundsToPlay = useLittleVigilanteSelector(
+    (state) => state.roundsToPlay
+  );
 
   return (
     <Flex direction="column" css={{ p: '$3' }}>
       <Flex direction="column" gap="2">
-        <Caption>Round {currentRound}</Caption>
+        <Caption>
+          Round {currentRound} of {roundsToPlay}
+        </Caption>
       </Flex>
       <Flex direction="column" css={{ py: '$3' }} gap="1">
         {players

--- a/libs/schema/@types/generated/LittleVigilanteState.ts
+++ b/libs/schema/@types/generated/LittleVigilanteState.ts
@@ -13,6 +13,7 @@ export class LittleVigilanteState extends Schema {
     @type("number") public currentTick!: number;
     @type("string") public conversationId!: string;
     @type("number") public currentRound!: number;
+    @type("number") public roundsToPlay!: number;
     @type("string") public calledVoteTargetedUserId!: string;
     @type("string") public calledVoteUserId!: string;
     @type({ set: "string" }) public currentStates: SetSchema<string> = new SetSchema<string>();

--- a/libs/schema/src/schemas/LittleVigilanteState.ts
+++ b/libs/schema/src/schemas/LittleVigilanteState.ts
@@ -19,6 +19,7 @@ export class LittleVigilanteState extends Schema {
   @type('number') currentTick = 0;
   @type('string') conversationId!: string;
   @type('number') currentRound = 1;
+  @type('number') roundsToPlay = 1;
   @type('string') calledVoteTargetedUserId = '';
   @type('string') calledVoteUserId = '';
 


### PR DESCRIPTION
https://trello.com/c/AKbBZp60/42-show-rounds-left-on-scoreboard

Little vig: Shows the total rounds to play on the scoreboard screen ("Round 1 of 3")

<img width="217" alt="Screen Shot 2023-02-26 at 4 51 43 PM" src="https://user-images.githubusercontent.com/223553/221448908-c779fb43-8bf9-4544-b7b6-de9f081a20ab.png">

I think in order to use this value in the UI, it needs to be in the Colyseus state, so I added it. lmk if that is not correct!